### PR TITLE
Implemented Scene Save/Load Functionality

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,27 +1,69 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class GameManager : MonoBehaviour
 {
+    //References
+    public Player player;
+    public Inventory playerInventory;
+    public int restaurantRating;
+    public FloatingTextManager floatingTextManager;
+    public int gold;
+    private string previousScene;
+
     public static GameManager instance;
     private void Awake()
     {
+        if (GameManager.instance != null)
+        {
+            Destroy(gameObject);
+            Destroy(player.gameObject);
+            Destroy(floatingTextManager.gameObject);
+            return;
+        }
+
         instance = this;
+        SceneManager.sceneLoaded += LoadState;
+        DontDestroyOnLoad(gameObject);
     }
-
-    Inventory playerInventory;
-
-    int gameInt;
-    int restaurantRating;
-
-    //Referencing floating text for later use
-    public FloatingTextManager floatingTextManager;
 
     //Ability to display floating text after being called with parameters.
     public void ShowText(string msg, int fontSize, Color color, Vector3 position, Vector3 motion, float duration)
     {
         floatingTextManager.Show(msg, fontSize, color, position, motion, duration);
     }
-    int gold;
+
+    //Save State
+
+    //STRING previousScene
+    //INT gold
+    public void SaveState()
+    {
+        string s = "";
+
+        //Attach saved values to the string here, separated by '|'
+        s += (SceneManager.GetActiveScene().name + "|");
+        s += (gold + "|");
+
+        PlayerPrefs.SetString("SaveState", s);
+        Debug.Log("SaveState");
+    }
+
+    public void LoadState(Scene s, LoadSceneMode mode)
+    {
+        if (!PlayerPrefs.HasKey("SaveState"))
+            return;
+
+        string[] data = PlayerPrefs.GetString("SaveState").Split('|');
+
+        // Set previous scene name
+        previousScene = data[0];
+
+        // Set player gold
+        gold = int.Parse(data[1]);
+
+        player.transform.position = GameObject.Find("SpawnPoint").transform.position;
+    }
 }

--- a/Assets/Scripts/SceneChange.cs
+++ b/Assets/Scripts/SceneChange.cs
@@ -10,7 +10,7 @@ public class SceneChange : Collideable
         if (coll.name == "Player_01")
         {
             //Teleport the player
-            //To add later: GameManager.instance.SaveState();
+            GameManager.instance.SaveState();
             string sceneName = sceneNames[Random.Range(0, sceneNames.Length)];
             UnityEngine.SceneManagement.SceneManager.LoadScene(sceneName);
         }


### PR DESCRIPTION
I have added code to the GameManager script that allows the transitions between scenes to not cause the game to reset values that relate to the player and their progress, i.e. gold, etc. This also will allow the spawn point of the player in a scene to depend on the last scene that they were in.